### PR TITLE
feat: [001 - transactionHistory, AccountLock]

### DIFF
--- a/.idea/dbnavigator.xml
+++ b/.idea/dbnavigator.xml
@@ -18,7 +18,8 @@
   <component name="DBNavigator.Project.DatabaseConsoleManager">
     <connection id="4d85ad17-c4e7-4b9a-b65e-80fede7ca534">
       <console name="Connection" type="STANDARD" schema="" session="Main"><![CDATA[create database fintech;
-alter table account drop foreign key FK3h9t1ijj5sog64jgq1x2oj0i9;]]></console>
+drop database fintech;
+alter table fintech.account drop foreign key FK3h9t1ijj5sog64jgq1x2oj0i9]]></console>
     </connection>
   </component>
   <component name="DBNavigator.Project.DatabaseEditorStateManager">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="EntryPointsManager">
+    <list size="1">
+      <item index="0" class="java.lang.String" itemvalue="org.springframework.beans.factory.annotation.Autowired" />
+    </list>
+  </component>
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="openjdk-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,12 +5,23 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="dd150fa6-60b1-449b-ab60-56f9e1413021" name="변경" comment="feat: [003 - Account Service, testCode]">
-      <change afterPath="$PROJECT_DIR$/src/main/java/com/zerobase/config/WebConfig.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/com/zerobase/controller/util/TokenArgumentResolver.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/com/zerobase/dto/TokenDto.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/com/zerobase/aop/AccountLockAop.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/com/zerobase/controller/TransactionHistoryController.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/com/zerobase/dto/TransactionDto.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/com/zerobase/service/TransactionHistoryService.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/test/java/com/zerobase/controller/TransactionHistoryControllerTest.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/test/java/com/zerobase/service/TransactionHistoryServiceTest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/dbnavigator.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/dbnavigator.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/misc.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/misc.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/zerobase/controller/AccountController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/zerobase/controller/AccountController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/com/zerobase/token/config/JwtAuthProvider.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/zerobase/token/config/JwtAuthProvider.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/zerobase/MainApplication.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/zerobase/MainApplication.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/zerobase/controller/TransactionController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/zerobase/controller/TransactionController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/zerobase/domain/Transaction.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/zerobase/domain/Transaction.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/zerobase/repository/AccountRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/zerobase/repository/AccountRepository.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/zerobase/repository/TransactionRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/zerobase/repository/TransactionRepository.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/zerobase/service/SignupService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/zerobase/service/SignupService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/zerobase/service/TransactionService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/zerobase/service/TransactionService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/resources/application.properties" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/application.properties" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -64,7 +75,7 @@
   <component name="Git.Settings">
     <option name="RECENT_BRANCH_BY_REPOSITORY">
       <map>
-        <entry key="$PROJECT_DIR$" value="feature/signup" />
+        <entry key="$PROJECT_DIR$" value="master" />
       </map>
     </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
@@ -118,6 +129,11 @@
     &quot;Gradle.TransactionControllerTest.failWithdrawAccount.executor&quot;: &quot;Run&quot;,
     &quot;Gradle.TransactionControllerTest.successDepositAccount.executor&quot;: &quot;Run&quot;,
     &quot;Gradle.TransactionControllerTest.successWithdrawAccount.executor&quot;: &quot;Run&quot;,
+    &quot;Gradle.TransactionHistoryControllerTest.executor&quot;: &quot;Run&quot;,
+    &quot;Gradle.TransactionHistoryControllerTest.failTransactionHistory.executor&quot;: &quot;Run&quot;,
+    &quot;Gradle.TransactionHistoryControllerTest.successTransactionHistory.executor&quot;: &quot;Run&quot;,
+    &quot;Gradle.TransactionHistoryServiceTest.failTransactionHistory.executor&quot;: &quot;Run&quot;,
+    &quot;Gradle.TransactionHistoryServiceTest.successTransactionHistory.executor&quot;: &quot;Run&quot;,
     &quot;Gradle.TransactionServiceTest.executor&quot;: &quot;Run&quot;,
     &quot;Gradle.TransactionServiceTest.fail.executor&quot;: &quot;Run&quot;,
     &quot;Gradle.TransactionServiceTest.failDepositAccount.executor&quot;: &quot;Run&quot;,
@@ -136,7 +152,7 @@
     &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
     &quot;com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary&quot;: &quot;JUnit5&quot;,
     &quot;com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5&quot;: &quot;&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;feature/transaction&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;feature/LockAndHistory&quot;,
     &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
     &quot;last_opened_file_path&quot;: &quot;C:/Users/pc/IdeaProjects/Fintech&quot;,
     &quot;project.structure.last.edited&quot;: &quot;모듈&quot;,
@@ -151,6 +167,7 @@
 }</component>
   <component name="RecentsManager">
     <key name="CreateClassDialog.RecentsKey">
+      <recent name="com.zerobase.type" />
       <recent name="com.zerobase.domain" />
     </key>
     <key name="CreateTestDialog.Recents.Supers">
@@ -161,7 +178,7 @@
       <recent name="com.zerobase.controller" />
     </key>
   </component>
-  <component name="RunManager" selected="Gradle.'Fintech.test'에 있는 테스트">
+  <component name="RunManager" selected="애플리케이션.MainApplication">
     <configuration name="MainApplication" type="Application" factoryName="Application" temporary="true" nameIsGenerated="true">
       <option name="MAIN_CLASS_NAME" value="com.zerobase.MainApplication" />
       <module name="Fintech.main" />
@@ -175,7 +192,7 @@
         <option name="Make" enabled="true" />
       </method>
     </configuration>
-    <configuration name="AccountControllerTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+    <configuration name="SignUpControllerTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -188,7 +205,7 @@
           <list>
             <option value=":test" />
             <option value="--tests" />
-            <option value="&quot;com.zerobase.controller.AccountControllerTest&quot;" />
+            <option value="&quot;com.zerobase.controller.SignUpControllerTest&quot;" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -199,7 +216,7 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
-    <configuration name="AccountControllerTest.successShowAccount" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+    <configuration name="TransactionHistoryServiceTest.failTransactionHistory" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -212,7 +229,7 @@
           <list>
             <option value=":test" />
             <option value="--tests" />
-            <option value="&quot;com.zerobase.controller.AccountControllerTest.successShowAccount&quot;" />
+            <option value="&quot;com.zerobase.service.TransactionHistoryServiceTest.failTransactionHistory&quot;" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -223,7 +240,7 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
-    <configuration name="SignInServiceTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+    <configuration name="TransactionHistoryServiceTest.successTransactionHistory" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -236,7 +253,7 @@
           <list>
             <option value=":test" />
             <option value="--tests" />
-            <option value="&quot;com.zerobase.service.SignInServiceTest&quot;" />
+            <option value="&quot;com.zerobase.service.TransactionHistoryServiceTest.successTransactionHistory&quot;" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -272,10 +289,10 @@
     <recent_temporary>
       <list>
         <item itemvalue="Gradle.'Fintech.test'에 있는 테스트" />
-        <item itemvalue="Gradle.AccountControllerTest" />
-        <item itemvalue="Gradle.AccountControllerTest.successShowAccount" />
+        <item itemvalue="Gradle.SignUpControllerTest" />
         <item itemvalue="애플리케이션.MainApplication" />
-        <item itemvalue="Gradle.SignInServiceTest" />
+        <item itemvalue="Gradle.TransactionHistoryServiceTest.failTransactionHistory" />
+        <item itemvalue="Gradle.TransactionHistoryServiceTest.successTransactionHistory" />
       </list>
     </recent_temporary>
   </component>

--- a/src/main/java/com/zerobase/MainApplication.java
+++ b/src/main/java/com/zerobase/MainApplication.java
@@ -3,12 +3,12 @@ package com.zerobase;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
 @EnableFeignClients
-//@EnableJpaRepositories
 public class MainApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/zerobase/aop/AccountLockAop.java
+++ b/src/main/java/com/zerobase/aop/AccountLockAop.java
@@ -1,0 +1,44 @@
+package com.zerobase.aop;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Component
+@Aspect
+@Slf4j
+public class AccountLockAop {
+  // 안전한 거래를 위해 계좌에 lock 걸기
+
+  // 동시에 여러 사용자가 계좌 잔액을 입금 출금이 발생할 수 있음 --> 멀티 쓰레드 환경
+  // HashMap 보단 ConcurrentHashMap 이 적합
+  private final ConcurrentHashMap<String, Lock> lockMap = new ConcurrentHashMap<>();
+
+  // TransactionService
+  @Around("execution(* com.zerobase.service.TransactionService.*(..)) && args(email,..)")
+  public Object accountLock(ProceedingJoinPoint joinPoint, String email) throws Throwable {
+
+    //ConcurrentHashMap 에 TransactionService 에서 가져온 첫 인자인 email 에 Lock 이 없다면 새로운 ReentrantLock 생성
+    Lock lock = lockMap.computeIfAbsent(email, e -> new ReentrantLock(true));
+
+    lock.lock(); // 락 획득
+    Object proceed = null;
+    try {
+      log.info("##################### AOP START #####################");
+      log.info("Current Tread  " + Thread.currentThread().getName() + "  User E-Mail: " + email);
+      proceed = joinPoint.proceed(); // 실제 TransactionService 실행
+    } catch (InterruptedException e) {
+      log.error("fail to use balance ", e);
+    } finally {
+      lock.unlock(); // 락 해제
+      log.info("##################### AOP END #####################");
+    }
+
+    return proceed;
+  }
+}

--- a/src/main/java/com/zerobase/controller/TransactionController.java
+++ b/src/main/java/com/zerobase/controller/TransactionController.java
@@ -22,7 +22,7 @@ public class TransactionController {
   private final TransactionService transactionService;
 
   @PostMapping("/deposit")
-  private ResponseEntity<AccountDto> depositAccount(
+  public ResponseEntity<AccountDto> depositAccount(
       @RequestBody @Valid TransactionForm form,
       TokenDto tokenDto
   ) {
@@ -31,7 +31,7 @@ public class TransactionController {
 
 
   @PostMapping("/withdraw")
-  private ResponseEntity<AccountDto> withdrawAccount(
+  public ResponseEntity<AccountDto> withdrawAccount(
       @RequestBody @Valid TransactionForm form,
       TokenDto tokenDto
   ) {

--- a/src/main/java/com/zerobase/controller/TransactionHistoryController.java
+++ b/src/main/java/com/zerobase/controller/TransactionHistoryController.java
@@ -1,0 +1,36 @@
+package com.zerobase.controller;
+
+import com.zerobase.dto.TransactionDto;
+import com.zerobase.service.TransactionHistoryService;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/search")
+@RequiredArgsConstructor
+public class TransactionHistoryController {
+
+  private final TransactionHistoryService transactionHistoryService;
+
+  @GetMapping("/date")
+  private ResponseEntity<Page<TransactionDto>> searchTransactionHistory(
+      @RequestParam("accountName") String accountName,
+      @RequestParam("startDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+      @RequestParam("endDate") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+      @PageableDefault(size = 50, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+  ) {
+    return ResponseEntity.ok(
+        transactionHistoryService.searchTransactionHistory(accountName, startDate, endDate,
+            pageable));
+  }
+}

--- a/src/main/java/com/zerobase/domain/Transaction.java
+++ b/src/main/java/com/zerobase/domain/Transaction.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -34,6 +35,8 @@ public class Transaction extends BaseEntity {
   private Long beforeTransaction;
 
   private Long afterTransaction;
+
+  private LocalDate date;
 
   @Enumerated(EnumType.STRING)
   private TransactionType transactionType; //  송금 / 인출 구분

--- a/src/main/java/com/zerobase/dto/TransactionDto.java
+++ b/src/main/java/com/zerobase/dto/TransactionDto.java
@@ -1,0 +1,38 @@
+package com.zerobase.dto;
+
+import com.zerobase.domain.Account;
+import com.zerobase.domain.Transaction;
+import com.zerobase.type.TransactionType;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TransactionDto {
+
+  private String accountName;
+
+  private Long beforeTransaction;
+
+  private Long afterTransaction;
+
+  @Enumerated(EnumType.STRING)
+  private TransactionType transactionType; //  송금 / 인출 구분
+
+  public static TransactionDto from(Transaction transaction) {
+    return TransactionDto.builder()
+        .accountName(transaction.getAccountName())
+        .beforeTransaction(transaction.getBeforeTransaction())
+        .afterTransaction(transaction.getAfterTransaction())
+        .transactionType(transaction.getTransactionType())
+        .build();
+  }
+}

--- a/src/main/java/com/zerobase/repository/AccountRepository.java
+++ b/src/main/java/com/zerobase/repository/AccountRepository.java
@@ -19,4 +19,6 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
   boolean existsByAccountNumber(String accountNumber);
 
   List<Account> findByAccountUser(AccountUser accountUser);
+
+  boolean existsByAccountName(String accountName);
 }

--- a/src/main/java/com/zerobase/repository/TransactionRepository.java
+++ b/src/main/java/com/zerobase/repository/TransactionRepository.java
@@ -1,10 +1,14 @@
 package com.zerobase.repository;
 
 import com.zerobase.domain.Transaction;
+import java.time.LocalDate;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TransactionRepository extends JpaRepository<Transaction, Long> {
 
+  Page<Transaction> findAllByDateBetween(LocalDate startDate, LocalDate endDate, Pageable pageable);
 }

--- a/src/main/java/com/zerobase/service/TransactionHistoryService.java
+++ b/src/main/java/com/zerobase/service/TransactionHistoryService.java
@@ -1,0 +1,40 @@
+package com.zerobase.service;
+
+import com.zerobase.domain.Transaction;
+import com.zerobase.dto.TransactionDto;
+import com.zerobase.exception.AccountException;
+import com.zerobase.repository.AccountRepository;
+import com.zerobase.repository.TransactionRepository;
+import com.zerobase.type.ErrorCode;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TransactionHistoryService {
+
+  private final AccountRepository accountRepository;
+  private final TransactionRepository transactionRepository;
+
+  @Transactional
+  public Page<TransactionDto> searchTransactionHistory(String accountName, LocalDate startDate,
+      LocalDate endDate,
+      Pageable pageable) {
+
+    // 조회하려는 계좌를 계좌 이름(유니크)으로 찾기
+    if (!accountRepository.existsByAccountName(accountName)) {
+      throw new AccountException(ErrorCode.ACCOUNT_NOT_FOUND);
+    }
+
+    Page<Transaction> page
+        = transactionRepository.findAllByDateBetween(startDate, endDate, pageable);
+
+    return page.map(TransactionDto::from);
+  }
+
+
+}

--- a/src/main/java/com/zerobase/service/TransactionService.java
+++ b/src/main/java/com/zerobase/service/TransactionService.java
@@ -10,6 +10,7 @@ import com.zerobase.repository.AccountUserRepository;
 import com.zerobase.repository.TransactionRepository;
 import com.zerobase.type.ErrorCode;
 import com.zerobase.type.TransactionType;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,13 +51,14 @@ public class TransactionService {
             .accountName(account.getAccountName())
             .beforeTransaction(beforeTransaction)
             .afterTransaction(afterTransaction)
+            .date(LocalDate.now())
             .transactionType(TransactionType.DEPOSIT)
             .build());
 
     return AccountDto.from(account);
   }
 
-
+  @Transactional
   public AccountDto withdrawAccount(String email, TransactionForm form) {
     // 이메일 체크
     if (!accountUserRepository.existsByEmail(email)) {
@@ -87,6 +89,7 @@ public class TransactionService {
             .accountName(account.getAccountName())
             .beforeTransaction(beforeTransaction)
             .afterTransaction(afterTransaction)
+            .date(LocalDate.now())
             .transactionType(TransactionType.WITHDRAW)
             .build());
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -11,5 +11,5 @@ spring.datasource.password=zerobase
 
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.show-sql=true
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.generate-ddl=true

--- a/src/test/java/com/zerobase/controller/TransactionHistoryControllerTest.java
+++ b/src/test/java/com/zerobase/controller/TransactionHistoryControllerTest.java
@@ -1,0 +1,105 @@
+package com.zerobase.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.config.SecurityConfig;
+import com.zerobase.config.WebConfig;
+import com.zerobase.dto.TransactionDto;
+import com.zerobase.exception.AccountException;
+import com.zerobase.repository.AccountRepository;
+import com.zerobase.service.TransactionHistoryService;
+import com.zerobase.token.config.JwtAuthProvider;
+import com.zerobase.type.ErrorCode;
+import com.zerobase.type.TransactionType;
+import java.util.Arrays;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.mockito.BDDMockito.*;
+
+@WebMvcTest(TransactionHistoryController.class)
+@Import({SecurityConfig.class, WebConfig.class})
+class TransactionHistoryControllerTest {
+
+  @MockBean
+  private TransactionHistoryService transactionHistoryService;
+
+  @MockBean
+  private JwtAuthProvider provider;
+
+  @MockBean
+  private AccountRepository accountRepository;
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+
+  @Test
+  @WithMockUser
+  @DisplayName("거래 내역 조회 - 성공")
+  void successTransactionHistory() throws Exception {
+
+    Page<TransactionDto> page = new PageImpl<>(Arrays.asList(
+        new TransactionDto("a1", 1000L, 2000L, TransactionType.DEPOSIT),
+        new TransactionDto("a1", 2000L, 0L, TransactionType.WITHDRAW)
+    ));
+    //given
+    given(transactionHistoryService.searchTransactionHistory(anyString(), any(), any(), any()))
+        .willReturn(page);
+    //when
+
+    //then
+    mockMvc.perform(MockMvcRequestBuilders.get("/search/date")
+            .param("accountName", "a1")
+            .param("startDate", "2024-05-05")
+            .param("endDate", "2024-12-24")
+        )
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.content[0].accountName").value("a1"))
+        .andExpect(jsonPath("$.content[0].beforeTransaction").value(1000L))
+        .andExpect(jsonPath("$.content[0].afterTransaction").value(2000L))
+        .andExpect(jsonPath("$.content[0].transactionType").value("DEPOSIT"))
+        .andExpect(jsonPath("$.content[1].accountName").value("a1"))
+        .andExpect(jsonPath("$.content[1].beforeTransaction").value(2000L))
+        .andExpect(jsonPath("$.content[1].afterTransaction").value(0L))
+        .andExpect(jsonPath("$.content[1].transactionType").value("WITHDRAW"))
+        .andDo(print());
+
+  }
+
+  @Test
+  @WithMockUser
+  @DisplayName("거래 내역 조회 - 실패(존재하지않는 계좌 이름으로 거래내역을 조회하려는 경우)")
+  void failTransactionHistory() throws Exception {
+    //given
+
+    given(transactionHistoryService.searchTransactionHistory(anyString(), any(), any(), any()))
+        .willThrow(new AccountException(ErrorCode.ACCOUNT_NOT_FOUND));
+    //when
+
+    //then
+    mockMvc.perform(MockMvcRequestBuilders.get("/search/date")
+            .param("accountName", "aaa")
+            .param("startDate", "2024-05-05")
+            .param("endDate", "2024-12-24"))
+        .andExpect(status().is4xxClientError())
+        .andExpect(jsonPath("$.errorCode").value("ACCOUNT_NOT_FOUND"))
+        .andExpect(jsonPath("$.errorMessage").value("계좌가 없습니다"))
+        .andDo(print());
+  }
+}

--- a/src/test/java/com/zerobase/service/TransactionHistoryServiceTest.java
+++ b/src/test/java/com/zerobase/service/TransactionHistoryServiceTest.java
@@ -1,0 +1,100 @@
+package com.zerobase.service;
+
+import com.zerobase.config.filter.JwtFilter;
+import com.zerobase.domain.Transaction;
+import com.zerobase.dto.TransactionDto;
+import com.zerobase.exception.AccountException;
+import com.zerobase.repository.AccountRepository;
+import com.zerobase.repository.TransactionRepository;
+import com.zerobase.token.config.JwtAuthProvider;
+import com.zerobase.type.ErrorCode;
+import com.zerobase.type.TransactionType;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TransactionHistoryServiceTest {
+
+  @Mock
+  private JwtFilter jwtFilter;
+
+  @Mock
+  private JwtAuthProvider provider;
+
+  @Mock
+  private AccountRepository accountRepository;
+
+  @Mock
+  private TransactionRepository transactionRepository;
+
+  @InjectMocks
+  private TransactionHistoryService transactionHistoryService;
+
+
+  @Test
+  @DisplayName("거래 내역 조회 - 성공")
+  void successTransactionHistory() {
+    Page<Transaction> page = new PageImpl<>(Arrays.asList(
+        new Transaction(1L, 1L, "a1", 1000L, 2000L, LocalDate.now(), TransactionType.DEPOSIT),
+        new Transaction(1L, 1L, "a1", 2000L, 0L, LocalDate.now(), TransactionType.WITHDRAW)
+    ));
+
+    PageRequest pageRequest = PageRequest.of(
+        0, 30, Sort.by(Sort.Direction.DESC, "createdAt")
+    );
+
+    //given
+    given(accountRepository.existsByAccountName(anyString()))
+        .willReturn(true);
+    given(transactionRepository.findAllByDateBetween(any(), any(), any()))
+        .willReturn(page);
+    //when
+    Page<TransactionDto> pages = transactionHistoryService.searchTransactionHistory("a1",
+        LocalDate.now(), LocalDate.now().plusMonths(2), pageRequest);
+    //then
+    assertEquals("a1", pages.get().toList().getFirst().getAccountName());
+    assertEquals(TransactionType.DEPOSIT, pages.get().toList().getFirst().getTransactionType());
+    assertEquals(1000L, pages.get().toList().getFirst().getBeforeTransaction());
+    assertEquals(2000L, pages.get().toList().getFirst().getAfterTransaction());
+
+    assertEquals("a1", pages.get().toList().get(1).getAccountName());
+    assertEquals(TransactionType.WITHDRAW, pages.get().toList().get(1).getTransactionType());
+    assertEquals(2000L, pages.get().toList().get(1).getBeforeTransaction());
+    assertEquals(0L, pages.get().toList().get(1).getAfterTransaction());
+  }
+
+
+  @Test
+  @DisplayName("거래 내역 조회 - 실패(존재하지않는 계좌 이름으로 거래내역을 조회하려는 경우)")
+  void failTransactionHistory() {
+
+    PageRequest pageRequest = PageRequest.of(
+        0, 30, Sort.by(Sort.Direction.DESC, "createdAt")
+    );
+    //given
+    given(accountRepository.existsByAccountName(anyString()))
+        .willReturn(false);
+    //when
+    AccountException accountException = assertThrows(AccountException.class,
+        () -> transactionHistoryService.searchTransactionHistory("a1", LocalDate.now(),
+            LocalDate.now().plusMonths(2), pageRequest));
+    //then
+    assertEquals(ErrorCode.ACCOUNT_NOT_FOUND, accountException.getErrorCode());
+  }
+}


### PR DESCRIPTION

### 변경사항


- 거래 내역 조회 추가 및 테스트 코드 작성 --> TransactionHistoryController, TransactionHistoryService

- 입금과 출금이 발생할때 보다 안전한 거래가 되도록 (다중 스레드 환경에서의 데이터 일관성을 보장하기 위해서) TransactionService 모든 메서드에 AOP(AccountLockAop)를 적용해, AccountLockAop 의 락을 사용하여 한 번에 하나의 스레드만 계좌에 접근하도록 했습니다
